### PR TITLE
[feat]: Added market buy API route

### DIFF
--- a/Cryptocurrency Trading Simulator/backend/src/app.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cookieParser from 'cookie-parser';
 
 import userRoutes from './routes/userRoutes';
+import orderRoutes from './routes/orderRoutes';
 
 const app = express();
 
@@ -9,5 +10,6 @@ app.use(express.json());
 app.use(cookieParser());
 
 app.use(userRoutes);
+app.use(orderRoutes);
 
 export default app;

--- a/Cryptocurrency Trading Simulator/backend/src/routes/orderRoutes.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/routes/orderRoutes.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from 'crypto';
+
+import express from 'express';
+import jwt from 'jsonwebtoken';
+
+import { Order } from '../schemas/orderSchema';
+import { User } from '../schemas/userSchema';
+
+const router = express.Router();
+
+/**
+ * Create a market order
+ * 
+ * @param {string} side - "buy" or "sell"
+ * @param {string} pair - currency pair (e.g. BTC/USD)
+ * @param {number} quantity - quantity of the currency being bought/sold
+ * @param {number} price - price of 1 unit of currency at the time of the order // TODO: get the price of the currency from exchange API\
+ * 
+ * @cookie token - JWT token
+ */
+router.post('/order/create/market', async (req: any, res: any) => {
+    const token = req.cookies.token;
+
+    if (!token) {
+        return res.status(401).json({ error: "Unauthorized" });
+    }
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || "") as { id: string; username: string, role: string };
+    const userUuid = decoded.id;
+
+    // TODO: get the price of the currency from exchange API
+    const { side, pair, quantity, price } = req.body;
+
+    const user = await User.findOne({ uuid: userUuid }) as { balance: number; holdings: { currency: string; quantity: number; averagePrice: number; value: number; }[]; };
+
+    const cost = quantity * price; // cost of the order
+    const bSufficientFunds: boolean = user.balance >= cost;
+
+    if (!bSufficientFunds) {
+        return res.status(400).json({ error: "Insufficient funds" });
+    }
+
+    const base = pair.split('/')[0]; // currency being bought/sold
+    // TODO: properly handle the quote currency (eg. if user isn't buying/selling USD)
+    const quote = pair.split('/')[1]; // currency used to buy/sell
+
+    let holdingExists = false;
+
+    user.holdings = user.holdings.map(holding => {
+        if (holding.currency === base) {
+            holdingExists = true;
+            if (side === "buy") {
+                holding.quantity += quantity;
+                holding.value += cost;
+                holding.averagePrice = (holding.averagePrice + price) / holding.quantity;
+                user.balance -= cost;
+            } else if (side === "sell") {
+                holding.quantity -= quantity;
+                holding.value -= cost;
+                if (holding.quantity === 0) {
+                    holding.averagePrice = 0;
+                } else {
+                    // TODO: check if this is correct
+                    holding.averagePrice = (holding.value - cost) / holding.quantity;
+                }
+                user.balance += cost;
+            }
+        }
+        return holding;
+    });
+
+    if (!holdingExists) {
+        if (side === "buy") {
+            user.holdings.push({
+                currency: base,
+                quantity: quantity,
+                averagePrice: price,
+                value: cost
+            });
+            user.balance -= cost;
+        } else if (side === "sell") {
+            return res.status(400).json({ error: "You don't have any holdings to sell" });
+        }
+    }
+
+    let uuid = randomUUID();
+    while(await Order.findOne({ uuid })) { // prevent duplicate uuids
+        uuid = randomUUID();
+    }
+
+    const order = new Order({
+        uuid,
+        userUuid,
+        side,
+        orderType: "market",
+        pair,
+        quantity,
+        cost,
+        price,
+        filled: true
+    });
+
+    try {
+        await order.save();
+        await User.updateOne({ uuid: userUuid }, user);
+        return res.status(200).json({ message: "Order created" });
+    } catch (err) {
+        return res.status(500).json({ error: err });
+    }
+});
+
+// TODO: add limit orders
+
+export default router;

--- a/Cryptocurrency Trading Simulator/backend/src/routes/userRoutes.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/routes/userRoutes.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import express from 'express';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
@@ -13,17 +15,28 @@ router.post('/user/register', async (req: any, res: any) => {
         return res.status(400).json({ error: "Missing required fields" });
     }
 
+    let uuid = randomUUID();
+
     try {
 
-        const existing = await User.findOne({ username });
+        let existing = await User.findOne({ uuid });
+        let attempts = 0;
+        const maxAttempts = 10;
 
-        if (existing) {
-            return res.status(400).json({ error: "Username already taken" });
+        while(existing && attempts < maxAttempts) { // prevent duplicate uuids
+            uuid = randomUUID();
+            existing = await User.findOne({ uuid });
+            attempts++;
+        }
+
+        if (attempts === maxAttempts) {
+            throw new Error('Unable to generate a unique UUID after multiple attempts');
         }
 
         const hashedPassword = await bcrypt.hash(password, 10);
 
         const user = new User({
+            uuid,
             username,
             password: hashedPassword,
             balance: 10000,
@@ -31,6 +44,7 @@ router.post('/user/register', async (req: any, res: any) => {
         });
 
         await user.save();
+        return res.status(200).json({ message: "User registered" });
     } catch (err) {
         return res.status(500).json({ error: err });
     }
@@ -55,7 +69,7 @@ router.post('/user/login', async (req: any, res: any) => {
         }
 
         // TODO: change to uuids
-        const token = jwt.sign({ id: user._id, username: user.username, role: "user" }, process.env.JWT_SECRET, {expiresIn: "30d"}); // Create token expires in 30 days; possibly change to uuids
+        const token = jwt.sign({ id: user.uuid, username: user.username, role: "user" }, process.env.JWT_SECRET, {expiresIn: "30d"}); // Create token expires in 30 days; possibly change to uuids
 
         res.cookie("token", token, { 
             httpOnly: true, // Prevent cookie from being accessed by client-side scripts
@@ -64,7 +78,7 @@ router.post('/user/login', async (req: any, res: any) => {
             maxAge: 1000 * 60 * 60 * 24 * 30 // 30 days 
         }); // Set token as cookie
 
-        return res.json({ message: "Logged in" });
+        return res.status(200).json({ message: "Logged in" });
     } catch (err) {
         return res.status(500).json({ error: err });
     }

--- a/Cryptocurrency Trading Simulator/backend/src/schemas/holdingSchema.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/schemas/holdingSchema.ts
@@ -1,0 +1,20 @@
+import { Schema, model } from 'mongoose';
+
+export const holdingSchema = new Schema({
+    currency: {
+        type: String,
+        required: true
+    },
+    quantity: {
+        type: Number,
+        required: true
+    },
+    averagePrice: { // average price of the currency at the time of purchase
+        type: Number,
+        required: true
+    },
+    value: { // value of the holding in USD (average price * quantity)
+        type: Number,
+        required: true
+    }
+});

--- a/Cryptocurrency Trading Simulator/backend/src/schemas/orderSchema.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/schemas/orderSchema.ts
@@ -1,0 +1,44 @@
+import { Schema, model } from 'mongoose';
+
+export const orderSchema = new Schema({
+    uuid: {
+        type: String,
+        required: true
+    },
+    userUuid: {
+        type: String,
+        required: true
+    },
+    side: { // buy or sell
+        type: String,
+        required: true
+    },
+    orderType: { // market orders for now TODO: add limit orders
+        type: String,
+        required: true
+    },
+    pair: { // pairs are the two cryptocurrencies that are being traded (e.g. BTC/USD)
+        type: String,
+        required: true
+    },
+    volume: { 
+        type: Number,
+        required: true
+    },
+    cost: {
+        type: Number,
+        required: true
+    },
+    price: {
+        type: Number,
+        required: true
+    },
+    filled: {
+        type: Boolean,
+        required: true
+    },
+    date: {
+        type: { type: Date, default: Date.now },
+        required: true
+    }
+});

--- a/Cryptocurrency Trading Simulator/backend/src/schemas/orderSchema.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/schemas/orderSchema.ts
@@ -21,15 +21,15 @@ export const orderSchema = new Schema({
         type: String,
         required: true
     },
-    volume: { 
+    quantity: { 
         type: Number,
         required: true
     },
-    cost: {
+    cost: { // cost of the order (quantity * price)
         type: Number,
         required: true
     },
-    price: {
+    price: { // price of the currency at the time of the order
         type: Number,
         required: true
     },
@@ -38,7 +38,8 @@ export const orderSchema = new Schema({
         required: true
     },
     date: {
-        type: { type: Date, default: Date.now },
-        required: true
+        type: { type: Date, default: Date.now }
     }
 });
+
+export const Order = model('Order', orderSchema);

--- a/Cryptocurrency Trading Simulator/backend/src/schemas/userSchema.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/schemas/userSchema.ts
@@ -2,10 +2,14 @@ import { Schema, model } from 'mongoose';
 
 // TODO: change to uuids
 export const userSchema = new Schema({
-    username: {
+    uuid: {
         type: String,
         required: true,
         unique: true
+    },
+    username: {
+        type: String,
+        required: true
     },
     password: {
         type: String,
@@ -15,7 +19,7 @@ export const userSchema = new Schema({
         type: Number,
         required: true
     },
-    schemaVersion: {
+    schemaVersion: { // development purposes
         type: Number,
         required: true
     }

--- a/Cryptocurrency Trading Simulator/backend/src/schemas/userSchema.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/schemas/userSchema.ts
@@ -22,6 +22,7 @@ export const userSchema = new Schema({
     },
     holdings: {
         type: [holdingSchema], // array of holdings (currencies)
+        default: [],
         required: true
     },
     schemaVersion: { // development purposes

--- a/Cryptocurrency Trading Simulator/backend/src/schemas/userSchema.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/schemas/userSchema.ts
@@ -1,5 +1,7 @@
 import { Schema, model } from 'mongoose';
 
+import { holdingSchema } from './holdingSchema';
+
 export const userSchema = new Schema({
     uuid: {
         type: String,
@@ -16,6 +18,10 @@ export const userSchema = new Schema({
     },
     balance: {
         type: Number,
+        required: true
+    },
+    holdings: {
+        type: [holdingSchema], // array of holdings (currencies)
         required: true
     },
     schemaVersion: { // development purposes

--- a/Cryptocurrency Trading Simulator/backend/src/schemas/userSchema.ts
+++ b/Cryptocurrency Trading Simulator/backend/src/schemas/userSchema.ts
@@ -1,6 +1,5 @@
 import { Schema, model } from 'mongoose';
 
-// TODO: change to uuids
 export const userSchema = new Schema({
     uuid: {
         type: String,


### PR DESCRIPTION
- Now uses UUIDs for user ID instead of mongo object ID
- Created schema for orders
- Added holdings array to store a user's crypto holdings
- Added API route for market buy orders

TODO:
- get price from crypto API
- handle different quote currencies during buys and sells (eg. pairs like BTC/ETH)